### PR TITLE
Responses implementation

### DIFF
--- a/mln/admin/__init__.py
+++ b/mln/admin/__init__.py
@@ -6,10 +6,10 @@ from django.apps import apps
 from django.contrib import admin
 from django.db.models import Q
 
-from ..models.dynamic import Attachment, Friendship, Message, MessageTemplate, MessageTemplateAttachment, NetworkerReplyTrigger, Profile, InventoryStack
+from ..models.dynamic import Attachment, Friendship, Message, Profile, InventoryStack
 from ..models.module import Module, ModuleSaveConcertArcade, ModuleSaveSoundtrack, module_settings_classes
 from ..models.module_settings_arcade import DeliveryArcadeTile
-from ..models.static import Answer, ArcadePrize, BlueprintInfo, BlueprintRequirement, ItemInfo, ItemType, MessageBody, ModuleEditorType, ModuleExecutionCost, ModuleInfo, ModuleSetupCost, ModuleYieldInfo, NetworkerFriendshipCondition, NetworkerFriendshipConditionSource, StartingStack, Question
+from ..models.static import Answer, ArcadePrize, BlueprintInfo, BlueprintRequirement, ItemInfo, ItemType, MessageBody, MessageTemplate, MessageTemplateAttachment, ModuleEditorType, ModuleExecutionCost, ModuleInfo, ModuleSetupCost, ModuleYieldInfo, NetworkerFriendshipCondition, NetworkerFriendshipConditionSource, NetworkerReplyTrigger, StartingStack, Question
 from .make_inline import custom, inlines, make_inline
 
 # Normal but customized admin interfaces

--- a/mln/models/dynamic.py
+++ b/mln/models/dynamic.py
@@ -169,11 +169,6 @@ class MessageTemplate(models.Model):
 	source = models.TextField(blank=True, null=True)
 	notes = models.TextField(blank=True, null=True)
 
-	def send(self, recipient, sender=None): 
-		message = Message.objects.create(sender=sender or self.networker, recipient=recipient, body=self.body)
-		for attachment in self.attachments.all():
-			message.attachments.create(item_id=attachment.item_id, qty=attachment.qty)
-
 class MessageTemplateAttachment(Stack):
 	"""A stack to be attached to a networker message."""
 	template = models.ForeignKey(MessageTemplate, related_name="attachments", on_delete=models.CASCADE)

--- a/mln/models/dynamic.py
+++ b/mln/models/dynamic.py
@@ -170,7 +170,7 @@ class MessageTemplate(models.Model):
 	notes = models.TextField(blank=True, null=True)
 
 	def send(self, recipient, sender=None): 
-		message = Message.objects.create(sender=sender or self.networker, recipient=recipient, body=self.response)
+		message = Message.objects.create(sender=sender or self.networker, recipient=recipient, body=self.body)
 		for attachment in self.attachments.all():
 			message.attachments.create(item_id=attachment.item_id, qty=attachment.qty)
 

--- a/mln/models/dynamic.py
+++ b/mln/models/dynamic.py
@@ -169,6 +169,11 @@ class MessageTemplate(models.Model):
 	source = models.TextField(blank=True, null=True)
 	notes = models.TextField(blank=True, null=True)
 
+	def send(self, recipient, sender=None): 
+		message = Message.objects.create(sender=sender or self.networker, recipient=recipient, body=self.response)
+		for attachment in self.attachments.all():
+			message.attachments.create(item_id=attachment.item_id, qty=attachment.qty)
+
 class NetworkerReplyTrigger(MessageTemplate):
 	"""A template for a message that triggers a networker's response."""
 	message_body = models.ForeignKey(MessageBody, related_name="+", on_delete=models.CASCADE, blank=True, null=True)

--- a/mln/models/dynamic.py
+++ b/mln/models/dynamic.py
@@ -174,6 +174,13 @@ class MessageTemplate(models.Model):
 		for attachment in self.attachments.all():
 			message.attachments.create(item_id=attachment.item_id, qty=attachment.qty)
 
+class MessageTemplateAttachment(Stack):
+	"""A stack to be attached to a networker message."""
+	template = models.ForeignKey(MessageTemplate, related_name="attachments", on_delete=models.CASCADE)
+
+	class Meta:
+		constraints = (models.UniqueConstraint(fields=("template", "item"), name="networker_template_attachment_unique_template_item"),)
+
 class NetworkerReplyTrigger(MessageTemplate):
 	"""A template for a message that triggers a networker's response."""
 	message_body = models.ForeignKey(MessageBody, related_name="+", on_delete=models.CASCADE, blank=True, null=True)
@@ -181,13 +188,6 @@ class NetworkerReplyTrigger(MessageTemplate):
 
 	def __str__(self):
 		return "From %s: %s" % (self.networker, self.response)
-
-class MessageTemplateAttachment(Stack):
-	"""A stack to be attached to a networker message."""
-	template = models.ForeignKey(MessageTemplate, related_name="attachments", on_delete=models.CASCADE)
-
-	class Meta:
-		constraints = (models.UniqueConstraint(fields=("template", "item"), name="networker_template_attachment_unique_template_item"),)
 
 def get_or_none(cls, *args, **kwargs):
 	"""Get a model instance according to the filters, or return None if no matching model instance was found."""

--- a/mln/models/dynamic.py
+++ b/mln/models/dynamic.py
@@ -158,39 +158,6 @@ class Friendship(models.Model):
 	def __str__(self):
 		return "%s -> %s: %s" % (self.from_user, self.to_user, self.get_status_display())
 
-class MessageTemplate(models.Model): 
-	"""An action that triggers a networker to send a response to the user."""
-	networker = models.ForeignKey(User, null=True, related_name="+", on_delete=models.CASCADE, limit_choices_to={"profile__is_networker": True})
-	body = models.ForeignKey(on_delete=models.deletion.CASCADE, related_name='+', to='mln.messagebody')
-
-	# Currently meant for devs to collect data on triggers, later to be properly integrated into the system.
-	networker_name = models.CharField(max_length=64, blank=True, null=True)
-	trigger = models.TextField(blank=True, null=True)
-	source = models.TextField(blank=True, null=True)
-	notes = models.TextField(blank=True, null=True)
-
-class MessageTemplateAttachment(Stack):
-	"""A stack to be attached to a networker message."""
-	template = models.ForeignKey(MessageTemplate, related_name="attachments", on_delete=models.CASCADE)
-
-	class Meta:
-		constraints = (models.UniqueConstraint(fields=("template", "item"), name="networker_template_attachment_unique_template_item"),)
-
-class NetworkerReplyTrigger(MessageTemplate):
-	"""A template for a message that triggers a networker's response."""
-	message_body = models.ForeignKey(MessageBody, related_name="+", on_delete=models.CASCADE, blank=True, null=True)
-	message_attachment = models.ForeignKey(ItemInfo, related_name="+", on_delete=models.CASCADE, blank=True, null=True)
-
-	def __str__(self):
-		return "From %s: %s" % (self.networker, self.body)
-
-	def evaluate(self, message, attachment): 
-		return (
-			(self.message_body is None or message.body == self.message_body) and  # compare bodies
-			(self.message_attachment is None) == (attachment is None) and  # don't compare null attachments
-			(self.message_attachment is None or attachment.item == self.message_attachment)  # compare attachments
-		)
-
 def get_or_none(cls, *args, **kwargs):
 	"""Get a model instance according to the filters, or return None if no matching model instance was found."""
 	try:

--- a/mln/models/dynamic.py
+++ b/mln/models/dynamic.py
@@ -189,6 +189,13 @@ class NetworkerReplyTrigger(MessageTemplate):
 	def __str__(self):
 		return "From %s: %s" % (self.networker, self.response)
 
+	def evaluate(self, message, attachment): 
+		return (
+			(self.message_body is None or message.body == self.message_body) and  # compare bodies
+			(self.message_attachment is None) == (attachment is None) and  # don't compare null attachments
+			(self.message_attachment is None or attachment.item == self.message_attachment)  # compare attachments
+		)
+
 def get_or_none(cls, *args, **kwargs):
 	"""Get a model instance according to the filters, or return None if no matching model instance was found."""
 	try:

--- a/mln/models/static.py
+++ b/mln/models/static.py
@@ -314,3 +314,36 @@ class ModuleSkin(models.Model):
 class StartingStack(Stack):
 	"""A stack that users start off with in their inventory when they create an account."""
 	item = models.OneToOneField(ItemInfo, related_name="+", on_delete=models.CASCADE)
+
+class MessageTemplate(models.Model): 
+	"""An action that triggers a networker to send a response to the user."""
+	networker = models.ForeignKey(User, null=True, related_name="+", on_delete=models.CASCADE, limit_choices_to={"profile__is_networker": True})
+	body = models.ForeignKey(on_delete=models.deletion.CASCADE, related_name='+', to='mln.messagebody')
+
+	# Currently meant for devs to collect data on triggers, later to be properly integrated into the system.
+	networker_name = models.CharField(max_length=64, blank=True, null=True)
+	trigger = models.TextField(blank=True, null=True)
+	source = models.TextField(blank=True, null=True)
+	notes = models.TextField(blank=True, null=True)
+
+class MessageTemplateAttachment(Stack):
+	"""A stack to be attached to a networker message."""
+	template = models.ForeignKey(MessageTemplate, related_name="attachments", on_delete=models.CASCADE)
+
+	class Meta:
+		constraints = (models.UniqueConstraint(fields=("template", "item"), name="networker_template_attachment_unique_template_item"),)
+
+class NetworkerReplyTrigger(MessageTemplate):
+	"""A template for a message that triggers a networker's response."""
+	message_body = models.ForeignKey(MessageBody, related_name="+", on_delete=models.CASCADE, blank=True, null=True)
+	message_attachment = models.ForeignKey(ItemInfo, related_name="+", on_delete=models.CASCADE, blank=True, null=True)
+
+	def __str__(self):
+		return "From %s: %s" % (self.networker, self.body)
+
+	def evaluate(self, message, attachment): 
+		return (
+			(self.message_body is None or message.body == self.message_body) and  # compare bodies
+			(self.message_attachment is None) == (attachment is None) and  # don't compare null attachments
+			(self.message_attachment is None or attachment.item == self.message_attachment)  # compare attachments
+		)

--- a/mln/models/static.py
+++ b/mln/models/static.py
@@ -31,6 +31,14 @@ class MLNError(Exception):
 		super().__init__()
 		self.id = id
 
+class MLNMessage: 
+	"""
+	These are messages that can be sent to the user on certain conditions.
+	They don't necessarily indicate an error within MLN, rather inform the user they need to do something different.
+	Like MLNError, these IDs refer to instances of MessageBody.
+	"""
+	I_DONT_GET_IT = 46222
+
 class ItemType(Enum):
 	"""Types of items. The main use is to place items into different inventory tabs."""
 	BACKGROUND = auto()

--- a/mln/services/message.py
+++ b/mln/services/message.py
@@ -54,7 +54,7 @@ def create_message(user, recipient_id, body_id):
 	_check_recipient(user, recipient_id)
 	return Message(sender=user, recipient_id=recipient_id, body_id=body_id)
 
-def send_message(message, attachment): 
+def send_message(message, attachment=None):
 	"""Send a message to someone."""
 	if not message.recipient.profile.is_networker:  # send the message directly
 		message.save()

--- a/mln/services/message.py
+++ b/mln/services/message.py
@@ -1,5 +1,5 @@
-from ..models.dynamic import Attachment, FriendshipStatus, Message, NetworkerReplyTrigger
-from ..models.static import MessageBody, MLNMessage
+from ..models.dynamic import Attachment, FriendshipStatus, Message
+from ..models.static import MessageBody, MLNMessage, NetworkerReplyTrigger
 from .friend import are_friends
 from .inventory import add_inv_item, remove_inv_item
 

--- a/mln/services/message.py
+++ b/mln/services/message.py
@@ -1,4 +1,4 @@
-from ..models.dynamic import FriendshipStatus, Message, NetworkerReplyTrigger
+from ..models.dynamic import Attachment, FriendshipStatus, Message, NetworkerReplyTrigger
 from ..models.static import MessageBody, MLNMessage
 from .friend import are_friends
 from .inventory import add_inv_item, remove_inv_item

--- a/mln/services/message.py
+++ b/mln/services/message.py
@@ -63,10 +63,15 @@ def send_message(message, attachment=None):
 	# Check for a networker's reply and send that to the user directly
 	for trigger in NetworkerReplyTrigger.objects.filter(networker=message.recipient):
 		if not trigger.evaluate(message, attachment): continue
-		trigger.send(message.sender)
+		send_template(trigger, message.sender)
 		break
 	else:  # networker doesn't have a trigger for this message
 		response = Message.objects.create(sender=message.recipient, recipient=message.sender, body_id=MLNMessage.I_DONT_GET_IT)
 		if attachment is not None:  # send the attachment back to the user
 			attachment.message = response
 			attachment.save()
+
+def send_template(template, recipient, sender=None): 
+	message = Message.objects.create(sender=sender or template.networker, recipient=recipient, body=template.body)
+	for attachment in template.attachments.all():
+		message.attachments.create(item_id=attachment.item_id, qty=attachment.qty)

--- a/mln/views/api/xml/message.py
+++ b/mln/views/api/xml/message.py
@@ -1,5 +1,5 @@
 """Mail functionality handlers."""
-from ....services.message import create_attachment, delete_message, detach_attachments, easy_reply, open_message, send_message
+from ....services.message import create_attachment, create_message, delete_message, detach_attachments, easy_reply, open_message, send_message
 
 def handle_message_delete(user, request):
 	message_id = int(request.get("messageID"))
@@ -18,7 +18,8 @@ def handle_message_easy_reply(user, request):
 def handle_message_easy_reply_with_attachments(user, request):
 	"""Like easy reply, but also attach items."""
 	message = handle_message_easy_reply(user, request)
-	handle_create_attachment(request, message)
+	attachment = handle_create_attachment(request, message)
+	send_message(message, attachment)
 
 def handle_message_get(user, request):
 	message_id = int(request.get("messageID"))
@@ -31,16 +32,21 @@ def handle_message_list(user, request):
 	return {"messages": messages}
 
 def handle_message_send(user, request):
-	recipient_id = int(request.get("recipientID"))
-	body_id = int(request.get("bodyID"))
-	return send_message(user, recipient_id, body_id)
+	message = handle_create_message(user, request)
+	send_message(message)
 
 def handle_message_send_with_attachment(user, request):
 	"""Send a message with attachment."""
-	message = handle_message_send(user, request)
-	handle_create_attachment(request, message)
+	message = handle_create_message(user, request)
+	attachment = handle_create_attachment(request, message)
+	send_message(message, attachment)
+
+def handle_create_message(user, request): 
+	recipient_id = int(request.get("recipientID"))
+	body_id = int(request.get("bodyID"))
+	return create_message(user, recipient_id, body_id)
 
 def handle_create_attachment(request, message):
 	item_id = int(request.get("itemID"))
 	qty = int(request.get("qty"))
-	create_attachment(message, item_id, qty)
+	return create_attachment(message, item_id, qty)


### PR DESCRIPTION
Builds off of https://github.com/MellonNet/mln-backend-emulator/pull/11 by adding the actual Python implementation to the `send_message` function. Unit tests are (hopefully temporarily) broken, but new ones are coming soon.

Expected behavior when sending a message
- if recipient is a human, send the message and attachment
- if the recipient is a networker and has a corresponding `NetworkerReplyTrigger`, send the response to the user
- otherwise, send the "I don't get it" response